### PR TITLE
feat: port base components of database crate to rust

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "nuvix",

--- a/rust-backend/Cargo.lock
+++ b/rust-backend/Cargo.lock
@@ -103,6 +103,11 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 [[package]]
 name = "database"
 version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror",
+]
 
 [[package]]
 name = "errno"

--- a/rust-backend/crates/database/Cargo.toml
+++ b/rust-backend/crates/database/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }

--- a/rust-backend/crates/database/src/doc.rs
+++ b/rust-backend/crates/database/src/doc.rs
@@ -1,0 +1,15 @@
+use serde::{Deserialize, Serialize};
+
+/// Represents a document in the database, encapsulating data of type `T`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Doc<T> {
+    #[serde(flatten)]
+    pub data: T,
+}
+
+impl<T> Doc<T> {
+    /// Creates a new Doc instance containing the provided data.
+    pub fn new(data: T) -> Self {
+        Self { data }
+    }
+}

--- a/rust-backend/crates/database/src/enums.rs
+++ b/rust-backend/crates/database/src/enums.rs
@@ -1,0 +1,108 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum AttributeType {
+    String,
+    Integer,
+    Float,
+    Boolean,
+    Timestamptz,
+    Jsonb,
+    Relationship,
+    Virtual,
+    Uuid,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum RelationSide {
+    Parent,
+    Child,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum OnDelete {
+    Cascade,
+    SetNull,
+    Restrict,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum IndexType {
+    Unique,
+    Key,
+    Fulltext,
+    Spatial,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum RelationType {
+    OneToOne,
+    OneToMany,
+    ManyToOne,
+    ManyToMany,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub enum Order {
+    #[serde(rename = "ASC")]
+    Asc,
+    #[serde(rename = "DESC")]
+    Desc,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum PermissionType {
+    Create,
+    Read,
+    Update,
+    Delete,
+    Write,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Events {
+    #[serde(rename = "*")]
+    All,
+    DatabaseList,
+    DatabaseCreate,
+    DatabaseDelete,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum QueryType {
+    Equal,
+    NotEqual,
+    LessThan,
+    LessThanEqual,
+    GreaterThan,
+    GreaterThanEqual,
+    Contains,
+    NotContains,
+    Search,
+    NotSearch,
+    IsNull,
+    IsNotNull,
+    Between,
+    NotBetween,
+    StartsWith,
+    NotStartsWith,
+    NotEndsWith,
+    EndsWith,
+    Select,
+    OrderDesc,
+    OrderAsc,
+    Limit,
+    Offset,
+    CursorAfter,
+    CursorBefore,
+    Or,
+    And,
+}

--- a/rust-backend/crates/database/src/error.rs
+++ b/rust-backend/crates/database/src/error.rs
@@ -1,0 +1,55 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum DatabaseError {
+    #[error("Document exception: {0}")]
+    DocException(String),
+
+    #[error("Authorization exception: {0}")]
+    AuthorizationException(String),
+
+    #[error("Conflict exception: {0}")]
+    ConflictException(String),
+
+    #[error("Dependency exception: {0}")]
+    DependencyException(String),
+
+    #[error("Duplicate exception: {0}")]
+    DuplicateException(String),
+
+    #[error("Limit exception: {0}")]
+    LimitException(String),
+
+    #[error("Order exception: {0}")]
+    OrderException(String),
+
+    #[error("Not found exception: {0}")]
+    NotFoundException(String),
+
+    #[error("Query exception: {0}")]
+    QueryException(String),
+
+    #[error("Relationship exception: {0}")]
+    RelationshipException(String),
+
+    #[error("Restricted exception: {0}")]
+    RestrictedException(String),
+
+    #[error("Structure exception: {0}")]
+    StructureException(String),
+
+    #[error("Timeout exception: {0}")]
+    TimeoutException(String),
+
+    #[error("Transaction exception: {0}")]
+    TransactionException(String),
+
+    #[error("Truncate exception: {0}")]
+    TruncateException(String),
+
+    #[error("Index exception: {0}")]
+    IndexException(String),
+
+    #[error("Other database error: {0}")]
+    Other(String),
+}

--- a/rust-backend/crates/database/src/lib.rs
+++ b/rust-backend/crates/database/src/lib.rs
@@ -9,4 +9,4 @@ pub use doc::Doc;
 pub use enums::*;
 pub use error::DatabaseError;
 pub use query::{Query, QueryBuilder};
-pub use types::AttributeOptions;
+pub use types::{Attribute, AttributeOptions, Collection, Index};

--- a/rust-backend/crates/database/src/lib.rs
+++ b/rust-backend/crates/database/src/lib.rs
@@ -1,14 +1,12 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
-}
+pub mod doc;
+pub mod enums;
+pub mod error;
+pub mod query;
+pub mod types;
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+// Re-export commonly used items directly for convenience
+pub use doc::Doc;
+pub use enums::*;
+pub use error::DatabaseError;
+pub use query::{Query, QueryBuilder};
+pub use types::AttributeOptions;

--- a/rust-backend/crates/database/src/query.rs
+++ b/rust-backend/crates/database/src/query.rs
@@ -1,0 +1,90 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use crate::enums::QueryType;
+
+/// Represents a single query operation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Query {
+    pub method: QueryType,
+    pub attribute: Option<String>,
+    pub values: Vec<Value>,
+}
+
+impl Query {
+    pub fn new(method: QueryType, attribute: Option<String>, values: Vec<Value>) -> Self {
+        Self {
+            method,
+            attribute,
+            values,
+        }
+    }
+}
+
+/// A builder for constructing a list of queries.
+#[derive(Debug, Clone, Default)]
+pub struct QueryBuilder {
+    queries: Vec<Query>,
+}
+
+impl QueryBuilder {
+    pub fn new() -> Self {
+        Self {
+            queries: Vec::new(),
+        }
+    }
+
+    /// Creates a new QueryBuilder instance from an existing array of Query objects.
+    pub fn from(queries: Vec<Query>) -> Self {
+        Self { queries }
+    }
+
+    /// Adds an equality condition.
+    pub fn equal<T: Serialize>(mut self, attribute: &str, value: T) -> Result<Self, serde_json::Error> {
+        let v = serde_json::to_value(value)?;
+        self.queries.push(Query::new(
+            QueryType::Equal,
+            Some(attribute.to_string()),
+            vec![v],
+        ));
+        Ok(self)
+    }
+
+    /// Adds a not equal condition.
+    pub fn not_equal<T: Serialize>(mut self, attribute: &str, value: T) -> Result<Self, serde_json::Error> {
+        let v = serde_json::to_value(value)?;
+        self.queries.push(Query::new(
+            QueryType::NotEqual,
+            Some(attribute.to_string()),
+            vec![v],
+        ));
+        Ok(self)
+    }
+
+    /// Returns the built queries.
+    pub fn build(self) -> Vec<Query> {
+        self.queries
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_query_builder() {
+        let builder = QueryBuilder::new()
+            .equal("status", "active").unwrap()
+            .not_equal("role", "guest").unwrap();
+
+        let queries = builder.build();
+
+        assert_eq!(queries.len(), 2);
+        assert_eq!(queries[0].method, QueryType::Equal);
+        assert_eq!(queries[0].attribute.as_deref(), Some("status"));
+        assert_eq!(queries[0].values[0], serde_json::Value::String("active".to_string()));
+
+        assert_eq!(queries[1].method, QueryType::NotEqual);
+        assert_eq!(queries[1].attribute.as_deref(), Some("role"));
+        assert_eq!(queries[1].values[0], serde_json::Value::String("guest".to_string()));
+    }
+}

--- a/rust-backend/crates/database/src/types.rs
+++ b/rust-backend/crates/database/src/types.rs
@@ -1,0 +1,13 @@
+use serde::{Deserialize, Serialize};
+use crate::enums::{RelationType, RelationSide, OnDelete};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AttributeOptions {
+    pub relation_type: RelationType,
+    pub side: RelationSide,
+    pub related_collection: String,
+    pub two_way: Option<bool>,
+    pub two_way_key: Option<String>,
+    pub on_delete: Option<OnDelete>,
+}

--- a/rust-backend/crates/database/src/types.rs
+++ b/rust-backend/crates/database/src/types.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
-use crate::enums::{RelationType, RelationSide, OnDelete};
+use serde_json::Value;
+use crate::enums::{AttributeType, RelationType, RelationSide, OnDelete, IndexType};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -10,4 +11,103 @@ pub struct AttributeOptions {
     pub two_way: Option<bool>,
     pub two_way_key: Option<String>,
     pub on_delete: Option<OnDelete>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Attribute {
+    #[serde(rename = "$id")]
+    pub id: String,
+    pub key: String,
+    #[serde(rename = "type")]
+    pub attribute_type: AttributeType,
+    pub size: Option<i32>,
+    pub required: Option<bool>,
+    pub array: Option<bool>,
+    pub filters: Option<Vec<String>>,
+    pub format: Option<String>,
+    pub format_options: Option<Value>, // Value since it's Record<string, any>
+    pub default: Option<Value>, // any
+    pub options: Option<Value>, // AttributeOptions | Record<string, any> -> keep as Value for flexibility or a custom enum
+    #[serde(rename = "__type")]
+    pub __type: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Index {
+    #[serde(rename = "$id")]
+    pub id: String,
+    pub key: Option<String>,
+    #[serde(rename = "type")]
+    pub index_type: IndexType,
+    pub attributes: Option<Vec<String>>,
+    pub orders: Option<Vec<Option<String>>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Collection {
+    #[serde(rename = "$id")]
+    pub id: String,
+    #[serde(rename = "$collection")]
+    pub collection: String,
+    #[serde(rename = "$schema")]
+    pub schema: Option<String>,
+    pub name: String,
+    pub attributes: Vec<Attribute>,
+    pub indexes: Vec<Index>,
+    pub document_security: bool,
+    pub enabled: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_collection_serialization() {
+        let json_data = r#"{
+            "$id": "col_123",
+            "$collection": "users",
+            "name": "Users",
+            "attributes": [
+                {
+                    "$id": "attr_1",
+                    "key": "email",
+                    "type": "string",
+                    "required": true
+                }
+            ],
+            "indexes": [
+                {
+                    "$id": "idx_1",
+                    "key": "email_idx",
+                    "type": "unique",
+                    "attributes": ["email"]
+                }
+            ],
+            "documentSecurity": true,
+            "enabled": true
+        }"#;
+
+        let collection: Collection = serde_json::from_str(json_data).unwrap();
+
+        assert_eq!(collection.id, "col_123");
+        assert_eq!(collection.collection, "users");
+        assert_eq!(collection.name, "Users");
+        assert_eq!(collection.attributes.len(), 1);
+        assert_eq!(collection.attributes[0].id, "attr_1");
+        assert_eq!(collection.attributes[0].key, "email");
+        assert_eq!(collection.attributes[0].attribute_type, AttributeType::String);
+        assert_eq!(collection.indexes.len(), 1);
+        assert_eq!(collection.indexes[0].id, "idx_1");
+        assert_eq!(collection.indexes[0].index_type, IndexType::Unique);
+        assert!(collection.document_security);
+
+        let serialized = serde_json::to_string(&collection).unwrap();
+        assert!(serialized.contains("\"$id\":\"col_123\""));
+        assert!(serialized.contains("\"$collection\":\"users\""));
+        assert!(serialized.contains("\"documentSecurity\":true"));
+    }
 }


### PR DESCRIPTION
Porting of basic components from the nuvix/db TypeScript package to the new Rust backend crate, including enums, exceptions, the Doc struct, and basic QueryBuilder functionality. Resolves #1.

---
*PR created automatically by Jules for task [4964021199858238617](https://jules.google.com/task/4964021199858238617) started by @ravikan6*